### PR TITLE
dolby: Make effect calls exception-safe across audioserver lifecycles

### DIFF
--- a/LunarisDolby/src/org/lunaris/dolby/audio/DolbyAudioEffect.kt
+++ b/LunarisDolby/src/org/lunaris/dolby/audio/DolbyAudioEffect.kt
@@ -15,16 +15,32 @@ class DolbyAudioEffect(priority: Int, audioSession: Int) : AudioEffect(
 ) {
 
     var dsOn: Boolean
-        get() = getIntParam(EFFECT_PARAM_ENABLE) == 1
+        get() = try {
+            getIntParam(EFFECT_PARAM_ENABLE) == 1
+        } catch (e: Exception) {
+            throw IllegalStateException("Failed to get dsOn", e)
+        }
         set(value) {
-            setIntParam(EFFECT_PARAM_ENABLE, if (value) 1 else 0)
-            enabled = value
+            try {
+                setIntParam(EFFECT_PARAM_ENABLE, if (value) 1 else 0)
+                enabled = value
+            } catch (e: Exception) {
+                throw IllegalStateException("Failed to set dsOn", e)
+            }
         }
 
     var profile: Int
-        get() = getIntParam(EFFECT_PARAM_PROFILE)
+        get() = try {
+            getIntParam(EFFECT_PARAM_PROFILE)
+        } catch (e: Exception) {
+            throw IllegalStateException("Failed to get profile", e)
+        }
         set(value) {
-            setIntParam(EFFECT_PARAM_PROFILE, value)
+            try {
+                setIntParam(EFFECT_PARAM_PROFILE, value)
+            } catch (e: Exception) {
+                throw IllegalStateException("Failed to set profile", e)
+            }
         }
 
     private fun setIntParam(param: Int, value: Int) {
@@ -47,19 +63,27 @@ class DolbyAudioEffect(priority: Int, audioSession: Int) : AudioEffect(
 
     fun resetProfileSpecificSettings(profile: Int = this.profile) {
         DolbyConstants.dlog(TAG, "resetProfileSpecificSettings: profile=$profile")
-        setIntParam(EFFECT_PARAM_RESET_PROFILE_SETTINGS, profile)
+        try {
+            setIntParam(EFFECT_PARAM_RESET_PROFILE_SETTINGS, profile)
+        } catch (e: Exception) {
+            throw IllegalStateException("Failed to reset profile specific settings for profile $profile", e)
+        }
     }
 
     fun setDapParameter(param: DsParam, values: IntArray, profile: Int = this.profile) {
         DolbyConstants.dlog(TAG, "setDapParameter: profile=$profile param=$param")
-        val length = values.size
-        val buf = ByteArray((length + 4) * 4)
-        int32ToByteArray(EFFECT_PARAM_SET_PROFILE_PARAMETER, buf, 0)
-        int32ToByteArray(length + 1, buf, 4)
-        int32ToByteArray(profile, buf, 8)
-        int32ToByteArray(param.id, buf, 12)
-        int32ArrayToByteArray(values, buf, 16)
-        checkStatus(setParameter(EFFECT_PARAM_CPDP_VALUES, buf))
+        try {
+            val length = values.size
+            val buf = ByteArray((length + 4) * 4)
+            int32ToByteArray(EFFECT_PARAM_SET_PROFILE_PARAMETER, buf, 0)
+            int32ToByteArray(length + 1, buf, 4)
+            int32ToByteArray(profile, buf, 8)
+            int32ToByteArray(param.id, buf, 12)
+            int32ArrayToByteArray(values, buf, 16)
+            checkStatus(setParameter(EFFECT_PARAM_CPDP_VALUES, buf))
+        } catch (e: Exception) {
+            throw IllegalStateException("Failed to set DAP parameter $param for profile $profile", e)
+        }
     }
 
     fun setDapParameter(param: DsParam, enable: Boolean, profile: Int = this.profile) =
@@ -71,10 +95,14 @@ class DolbyAudioEffect(priority: Int, audioSession: Int) : AudioEffect(
     fun getDapParameter(param: DsParam, profile: Int = this.profile): IntArray {
         DolbyConstants.dlog(TAG, "getDapParameter: profile=$profile param=$param")
         val length = param.length
-        val buf = ByteArray((length + 2) * 4)
-        val p = (param.id shl 16) + (profile shl 8) + EFFECT_PARAM_GET_PROFILE_PARAMETER
-        checkStatus(getParameter(p, buf))
-        return byteArrayToInt32Array(buf, length)
+        return try {
+            val buf = ByteArray((length + 2) * 4)
+            val p = (param.id shl 16) + (profile shl 8) + EFFECT_PARAM_GET_PROFILE_PARAMETER
+            checkStatus(getParameter(p, buf))
+            byteArrayToInt32Array(buf, length)
+        } catch (e: Exception) {
+            throw IllegalStateException("Failed to get DAP parameter $param for profile $profile", e)
+        }
     }
 
     fun getDapParameterBool(param: DsParam, profile: Int = this.profile): Boolean =

--- a/LunarisDolby/src/org/lunaris/dolby/data/DolbyRepository.kt
+++ b/LunarisDolby/src/org/lunaris/dolby/data/DolbyRepository.kt
@@ -50,21 +50,39 @@ class DolbyRepository(private val context: Context) : AutoCloseable {
         }
     }
 
-    private fun checkEffect() {
+    private fun recreateEffect(): Boolean {
+        return try {
+            val newEffect = createDolbyEffect()
+            try {
+                dolbyEffect.release()
+            } catch (re: Exception) {
+                DolbyConstants.dlog(TAG, "Error releasing old effect: ${re.message}")
+            }
+            dolbyEffect = newEffect
+            restoreSavedProfileIfNeeded()
+            true
+        } catch (e: Exception) {
+            DolbyConstants.dlog(TAG, "Failed to recreate effect: ${e.message}")
+            false
+        }
+    }
+
+    private fun checkEffect(): Boolean {
         if (isReleased) {
             DolbyConstants.dlog(TAG, "Repository released, skipping effect check")
-            return
+            return false
         }
         
-        try {
+        return try {
             if (!dolbyEffect.hasControl()) {
                 DolbyConstants.dlog(TAG, "Lost audio effect control, recreating")
-                dolbyEffect.release()
-                dolbyEffect = createDolbyEffect()
-                restoreSavedProfileIfNeeded()
+                recreateEffect()
+            } else {
+                true
             }
         } catch (e: Exception) {
-            DolbyConstants.dlog(TAG, "Error checking effect: ${e.message}")
+            DolbyConstants.dlog(TAG, "Error checking effect: ${e.message}, recreating")
+            recreateEffect()
         }
     }
 
@@ -74,12 +92,16 @@ class DolbyRepository(private val context: Context) : AutoCloseable {
     }
 
     private fun restoreSavedProfileIfNeeded() {
-        val savedProfile = readSavedProfile() ?: return
-        if (dolbyEffect.profile != savedProfile) {
-            dolbyEffect.profile = savedProfile
+        try {
+            val savedProfile = readSavedProfile() ?: return
+            if (dolbyEffect.profile != savedProfile) {
+                dolbyEffect.profile = savedProfile
+            }
+            restoreProfilePreset(savedProfile)
+            applyProfileSettings(savedProfile)
+        } catch (e: Exception) {
+            DolbyConstants.dlog(TAG, "Failed in restoreSavedProfileIfNeeded: ${e.message}")
         }
-        restoreProfilePreset(savedProfile)
-        applyProfileSettings(savedProfile)
     }
 
     private fun applyProfileSettings(profile: Int) {
@@ -121,11 +143,15 @@ class DolbyRepository(private val context: Context) : AutoCloseable {
     }
 
     fun applySavedState() {
-    checkEffect()
-        val enabled = defaultPrefs.getBoolean(DolbyConstants.PREF_ENABLE, false)
-        dolbyEffect.dsOn = enabled
-        if (enabled) {
-            restoreSavedProfileIfNeeded()
+        if (!checkEffect()) return
+        try {
+            val enabled = defaultPrefs.getBoolean(DolbyConstants.PREF_ENABLE, false)
+            dolbyEffect.dsOn = enabled
+            if (enabled) {
+                restoreSavedProfileIfNeeded()
+            }
+        } catch (e: Exception) {
+            DolbyConstants.dlog(TAG, "applySavedState failed: ${e.message}")
         }
     }
 

--- a/LunarisDolby/src/org/lunaris/dolby/service/DolbyEffectService.kt
+++ b/LunarisDolby/src/org/lunaris/dolby/service/DolbyEffectService.kt
@@ -55,9 +55,13 @@ class DolbyEffectService : Service() {
 
     private val playbackCallback = object : AudioManager.AudioPlaybackCallback() {
         override fun onPlaybackConfigChanged(configs: MutableList<AudioPlaybackConfiguration>?) {
-            val isActive = configs?.any { it.isActive } == true
-            if (isActive) {
-                repository.applySavedState()
+            try {
+                val isActive = configs?.any { it.isActive } == true
+                if (isActive) {
+                    repository.applySavedState()
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to apply state on playback config change", e)
             }
         }
     }


### PR DESCRIPTION
- when audioserver crashes or restarts, native AudioEffect handles become uninitialized
- catch exceptions in AudioEffect getters/setters, recreate lost effects cleanly in checkEffect(), and prevent crashes in DolbyEffectService callbacks

Change-Id: I9e5089f507a1f7e8e4257d180d6684d23cd380ae